### PR TITLE
set config files according to redis-server@ service

### DIFF
--- a/redis/6.0/redis-queues.conf
+++ b/redis/6.0/redis-queues.conf
@@ -105,7 +105,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /var/run/redis/redis-queues-server.sock
+unixsocket /var/run/redis-queues/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -247,7 +247,7 @@ supervised no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis/redis-queues-server.pid
+pidfile /var/run/redis-queue/rediss-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/6.0/redis-queues.conf
+++ b/redis/6.0/redis-queues.conf
@@ -247,7 +247,7 @@ supervised no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis-queue/rediss-server.pid
+pidfile /var/run/redis-queues/redis-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/6.0/redis-sessions.conf
+++ b/redis/6.0/redis-sessions.conf
@@ -105,7 +105,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /var/run/redis/redis-sessions-server.sock
+unixsocket /var/run/redis-sessions/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -247,7 +247,7 @@ supervised no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis/redis-sessions-server.pid
+pidfile /var/run/redis-sessions/redis-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/7.0/redis-queues.conf
+++ b/redis/7.0/redis-queues.conf
@@ -152,7 +152,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /var/run/redis/redis-queues-server.sock
+unixsocket /var/run/redis-queues/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -338,7 +338,7 @@ daemonize yes
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis/redis-queues-server.pid
+pidfile /var/run/redis-queue/rediss-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/7.0/redis-queues.conf
+++ b/redis/7.0/redis-queues.conf
@@ -338,7 +338,7 @@ daemonize yes
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis-queue/rediss-server.pid
+pidfile /var/run/redis-queues/redis-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/7.0/redis-sessions.conf
+++ b/redis/7.0/redis-sessions.conf
@@ -152,7 +152,7 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /var/run/redis/redis-sessions-server.sock
+unixsocket /var/run/redis-sessions/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -338,7 +338,7 @@ daemonize yes
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis/redis-sessions-server.pid
+pidfile /var/run/redis-session/rediss-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/7.0/redis-sessions.conf
+++ b/redis/7.0/redis-sessions.conf
@@ -338,7 +338,7 @@ daemonize yes
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis-session/rediss-server.pid
+pidfile /var/run/redis-sessions/redis-server.pid
 
 # Specify the server verbosity level.
 # This can be one of:

--- a/redis/redis-server@.service
+++ b/redis/redis-server@.service
@@ -1,0 +1,74 @@
+# Templated service file for redis-server(1)
+#
+# Located at: /lib/systemd/system/redis-server@.service
+#
+# Each instance of redis-server requires its own configuration file:
+#
+#   $ cp /etc/redis/redis.conf /etc/redis/redis-myname.conf
+#   $ chown redis:redis /etc/redis/redis-myname.conf
+#
+# Ensure each instance is using their own database:
+#
+#   $ sed -i -e 's@^dbfilename .*@dbfilename dump-myname.rdb@' /etc/redis/redis-myname.conf
+#
+# We then listen exlusively on UNIX sockets to avoid TCP port collisions:
+#
+#   $ sed -i -e 's@^port .*@port 0@' /etc/redis/redis-myname.conf
+#   $ sed -i -e 's@^\(# \)\{0,1\}unixsocket .*@unixsocket /var/run/redis-myname/redis-server.sock@' /etc/redis/redis-myname.conf
+#
+# ... and ensure we are logging, etc. in a unique location:
+#
+#   $ sed -i -e 's@^logfile .*@logfile /var/log/redis/redis-server-myname.log@' /etc/redis/redis-myname.conf
+#   $ sed -i -e 's@^pidfile .*@pidfile /run/redis-myname/redis-server.pid@' /etc/redis/redis-myname.conf
+#
+# We can then start the service as follows, validating we are using our own
+# configuration:
+#
+#   $ systemctl start redis-server@myname.service
+#   $ redis-cli -s /var/run/redis-myname/redis-server.sock info | grep config_file
+#
+#  -- Chris Lamb <lamby@debian.org>  Mon, 09 Oct 2017 22:17:24 +0100
+[Unit]
+Description=Advanced key-value store (%I)
+After=network.target
+Documentation=http://redis.io/documentation, man:redis-server(1)
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/redis-server /etc/redis/redis-%i.conf --supervised systemd --daemonize no
+PIDFile=/run/redis-%i/redis-server.pid
+TimeoutStopSec=0
+Restart=always
+User=redis
+Group=redis
+RuntimeDirectory=redis-%i
+RuntimeDirectoryMode=2755
+
+UMask=007
+PrivateTmp=yes
+LimitNOFILE=65535
+PrivateDevices=yes
+ProtectHome=yes
+ReadOnlyDirectories=/
+ReadWritePaths=-/var/lib/redis
+ReadWritePaths=-/var/log/redis
+ReadWritePaths=-/var/run/redis-%i
+
+NoNewPrivileges=true
+CapabilityBoundingSet=CAP_SETGID CAP_SETUID CAP_SYS_RESOURCE
+MemoryDenyWriteExecute=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# redis-server can write to its own config file when in cluster mode so we
+# permit writing there by default. If you are not using this feature, it is
+# recommended that you replace the following lines with "ProtectSystem=full".
+ProtectSystem=true
+ReadWriteDirectories=-/etc/redis
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ik maak dit een PR ter controle, weet je toevallig nog waarom de mappen veranderd waren in de config?

Ik gok dat het is omdat we niet het bestaande service bestand onderaan de PR gebruikten waardoor hij de juiste bestanden en mappen niet aanmaakte om in te werken.

Je kan namelijk geen bestanden in een zelfde map in `/var/run` zetten, dit zijn voor draaiende programmas. Wanneer je een nieuwe opstart leegt hij eerst deze map