### PR TITLE
Add timeouts of 5 minutes to all redis calls

### DIFF
--- a/redis/6.0/redis-queues.conf
+++ b/redis/6.0/redis-queues.conf
@@ -109,7 +109,7 @@ unixsocket /var/run/redis-queues/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #

--- a/redis/6.0/redis-sessions.conf
+++ b/redis/6.0/redis-sessions.conf
@@ -109,7 +109,7 @@ unixsocket /var/run/redis-sessions/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #

--- a/redis/6.0/redis.conf
+++ b/redis/6.0/redis.conf
@@ -109,7 +109,7 @@ unixsocket /var/run/redis/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #

--- a/redis/7.0/redis-queues.conf
+++ b/redis/7.0/redis-queues.conf
@@ -156,7 +156,7 @@ unixsocket /var/run/redis-queues/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #

--- a/redis/7.0/redis-sessions.conf
+++ b/redis/7.0/redis-sessions.conf
@@ -156,7 +156,7 @@ unixsocket /var/run/redis-sessions/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #

--- a/redis/7.0/redis.conf
+++ b/redis/7.0/redis.conf
@@ -156,7 +156,7 @@ unixsocket /var/run/redis/redis-server.sock
 unixsocketperm 777
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout 0
+timeout 300
 
 # TCP keepalive.
 #


### PR DESCRIPTION
It is expected the infinite timeout causes some connections to stay open.

In the span of a couple weeks/months saturating the max connections